### PR TITLE
Fixed false positive bug in Oracle TNS Listener Checker module

### DIFF
--- a/modules/auxiliary/scanner/oracle/tnspoison_checker.rb
+++ b/modules/auxiliary/scanner/oracle/tnspoison_checker.rb
@@ -42,8 +42,19 @@ class MetasploitModule < Msf::Auxiliary
       send_packet = tns_packet("(CONNECT_DATA=(COMMAND=service_register_NSGR))")
       sock.put(send_packet)
       packet = sock.read(100)
+      hex_packet = Rex::Text.to_hex(packet, prefix = ':')
+      split_hex = hex_packet.split(":")
       find_packet = /\(ERROR_STACK=\(ERROR=/ === packet
-      find_packet == true ? print_error("#{ip}:#{rport} is not vulnerable ") : print_good("#{ip}:#{rport} is vulnerable")
+      #find_packet == true ? print_error("#{ip}:#{rport} is not vulnerable ") : print_good("#{ip}:#{rport} is vulnerable")
+      if find_packet == true
+            print_error("#{ip}:#{rport} is not vulnerable")
+      elsif split_hex[5] == "02"
+            print_good("#{ip}:#{rport} is vulnerable")
+      elsif split_hex[5] == "04"
+            print_error("#{ip}:#{rport} is not vulnerable")
+      else
+            print_error("#{ip}:#{rport} might not be vulnerable")
+      end
       # TODO: Module should report_vuln if this finding is solid.
       rescue ::Rex::ConnectionError, ::Errno::EPIPE
       print_error("#{ip}:#{rport} unable to connect to the server")


### PR DESCRIPTION
Oracle TNS Listener Checker module has a bug to mark a target as vulnerable if the received response data does not contain `(ERROR_STACK=(ERROR=`. For example, if the response packet contains `AnythingCanExistHere` then this module will return the target host is vulnerable which is  incorrect. 
## Verification

In `RPORT` set a port which does not serve TNS Listener. For example an HTTP service.
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/oracle/tnspoison_checker`
- [ ] `set RHOSTS target_host`
- [ ] `set RPORT open_port`
- [ ] `run`

Checking for "(ERROR_STACK=(ERROR=" is not enough to mark a target as vulnerable. Checking TNS response packet bytes for "Accept" and "Refuse" is required to be sure.

Reference: https://thesprawl.org/research/oracle-tns-protocol/

False positive screenshot:
![bug_fix2](https://cloud.githubusercontent.com/assets/5358495/16177285/5ca09190-3645-11e6-8dc1-15b92d30416b.png)
